### PR TITLE
updates base url to correct url

### DIFF
--- a/src/fiddle-client.js
+++ b/src/fiddle-client.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch');
 
-const base = "https://fiddle.fastlydemo.net";
+const base = "https://fiddle.fastly.dev";
 
 /**
  * Get a fiddle


### PR DESCRIPTION
# Overview

When pulling and running the fastly test environment it fails due to incorrect base URL. Updated the base URL to use the correct one.